### PR TITLE
Make GenerateTablesCommand public

### DIFF
--- a/src/Symfony/services.yml
+++ b/src/Symfony/services.yml
@@ -2,9 +2,9 @@ services:
     _defaults:
         autowire: true
 
-    database_access_generator.generate_tables:
-        class: GW\DQO\Symfony\GenerateTablesCommand
+    GW\DQO\Symfony\GenerateTablesCommand:
         tags: [{name: console.command}]
+        public: true
 
     GW\DQO\Generator\TableFactory: ~
     GW\DQO\Generator\Renderer: ~


### PR DESCRIPTION
It allows to use GenerateTablesCommand outside of symfony full framework